### PR TITLE
Updates provider version

### DIFF
--- a/.github/workflows/code-quality-terraform.yml
+++ b/.github/workflows/code-quality-terraform.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  TERRAFORM_VERSION: 0.12.20
+  TERRAFORM_VERSION: 0.13.2
   TERRAFORM_ACTIONS_COMMENT: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## Requirements
 
-This module requires Terraform version `0.12.0` or newer.
+This module requires Terraform version `0.13.0` or newer.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the module to your Terraform resources like so:
 ```hcl
 module "gsuite_records" {
   source              = "operatehappy/route53-gsuite-records/aws"
-  version             = "0.9.0"
+  version             = "1.0.0"
   zone_id             = "Z3P5QSUBK4POTI"
 
   mx_verification_record_prefix = "2vw...juq"
@@ -248,7 +248,7 @@ Described in _Help Center_ article [Set up the "naked" domain address for your s
 
 ## Author Information
 
-This module is maintained by the contributors listed on [GitHub](https://github.com/operatehappy/terraform-aws-route53-workmail-records/graphs/contributors)
+This module is maintained by the contributors listed on [GitHub](https://github.com/operatehappy/terraform-aws-route53-gsuite-records/graphs/contributors).
 
 Development of this module was sponsored by [Operate Happy](https://github.com/operatehappy).
 
@@ -256,7 +256,7 @@ Development of this module was sponsored by [Operate Happy](https://github.com/o
 
 Licensed under the Apache License, Version 2.0 (the "License").
 
-You may obtain a copy of the License at [apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+You may obtain a copy of the License at [apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an _"AS IS"_ basis, without WARRANTIES or conditions of any kind, either express or implied.
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = "> 2.10.0"

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "> 2.10.0"
+    aws = ">= 3.4.0"
   }
 }


### PR DESCRIPTION
This PR updates the underlying version of Terraform (`0.12.20` to `0.13.2`) and the AWS Provider (to `3.4.0`)

I intend to release this as `1.0.0` as this module is now feature complete.